### PR TITLE
Add timeout to requests call to prevent DoS via hangs

### DIFF
--- a/application/common/auth.py
+++ b/application/common/auth.py
@@ -21,7 +21,8 @@ def fetch_credentials(username: str, authpoint: str, headers=None) -> dict:
     cust_headers = {}
     if headers:
         cust_headers["Authorization"] = headers
-    response = requests.get(url, headers=cust_headers)
+    # Prevent indefinite hangs / resource exhaustion by enforcing a reasonable timeout.
+    response = requests.get(url, headers=cust_headers, timeout=(3.05, 10))
     if response.ok:
         data = {}
         if response.status_code != 204:


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Add timeout to requests call in auth credential fetch in `application/common/auth.py` (Line: 24)

**Risk:** Outbound `requests.get()` calls without a timeout can hang indefinitely, consuming worker threads/sockets and enabling a DoS via resource exhaustion (CWE-770).

**Fix:** Added an explicit connect/read timeout `(3.05, 10)` to the `requests.get()` call in `fetch_credentials()` so the request fails fast instead of hanging forever.

**Review notes:** Timeout values were chosen to be reasonable defaults; adjust if the auth service requires longer response times.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*