### PR TITLE
Fix DoS risk by adding timeout to requests call

### DIFF
--- a/application/common/auth.py
+++ b/application/common/auth.py
@@ -21,7 +21,8 @@ def fetch_credentials(username: str, authpoint: str, headers=None) -> dict:
     cust_headers = {}
     if headers:
         cust_headers["Authorization"] = headers
-    response = requests.get(url, headers=cust_headers)
+    # Add a timeout to prevent indefinite hangs and resource exhaustion (CWE-770)
+    response = requests.get(url, headers=cust_headers, timeout=(3.05, 10))
     if response.ok:
         data = {}
         if response.status_code != 204:


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Add requests timeout to auth service call in `application/common/auth.py` (Line: 24)

**Risk:** Outbound HTTP requests to the auth service were made without a timeout, allowing connections to hang indefinitely and potentially exhaust worker threads/sockets (DoS via uncontrolled resource consumption, CWE-770).

**Fix:** Added an explicit `timeout` to the `requests.get()` call in `fetch_credentials()` using a connect/read timeout tuple.

**Review notes:** Timeout values are `(3.05, 10)` (connect, read); adjust if your auth service requires longer responses.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*