### PR TITLE
Upgrade Django to 4.2.29 to fix QuerySet.order_by SQL injection

### DIFF
--- a/application/requirements.txt
+++ b/application/requirements.txt
@@ -2,7 +2,7 @@ aiohttp==3.7.2
 aiojira==0.1.14
 asyncio==3.4.3
 django-cors-headers==3.6.0
-django==3.0.5
+django==4.2.29
 djangorestframework==3.12.2
 flake8==3.8.4
 jira==2.0.0


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Upgrade Django to patched version to prevent order_by SQLi in `application/requirements.txt`

**Risk:** Django <3.1.13 / <3.2.5 is vulnerable to SQL injection when `QuerySet.order_by()` is called with untrusted user input, potentially allowing arbitrary SQL to be injected via crafted ordering parameters.

**Fix:** Updated the pinned Django dependency from `3.0.5` to `4.2.29`, a version with no known vulnerabilities in our scanner and which includes fixes for the reported `order_by` SQL injection issue.

**Review notes:** This is a major-version upgrade (3.0 → 4.2); run the application/test suite to confirm framework-level compatibility (middlewares, settings, and third-party Django packages).

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*