### PR TITLE
Fix DoS risk by adding timeout to auth service requests

### DIFF
--- a/application/common/auth.py
+++ b/application/common/auth.py
@@ -21,7 +21,9 @@ def fetch_credentials(username: str, authpoint: str, headers=None) -> dict:
     cust_headers = {}
     if headers:
         cust_headers["Authorization"] = headers
-    response = requests.get(url, headers=cust_headers)
+    # Use timeouts to prevent indefinite hangs and socket exhaustion (CWE-770).
+    # Tuple format: (connect timeout, read timeout)
+    response = requests.get(url, headers=cust_headers, timeout=(3.05, 10))
     if response.ok:
         data = {}
         if response.status_code != 204:


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Add timeout to auth service request in `application/common/auth.py` (Line: 24)

**Risk:** `requests.get()` was called without a timeout when contacting the auth service, allowing the connection to hang indefinitely and potentially exhaust worker threads/sockets (DoS; CWE-770).

**Fix:** Added an explicit connect/read timeout tuple to the `requests.get()` call in `fetch_credentials()` so stalled upstream connections fail fast instead of consuming resources indefinitely.

**Review notes:** Timeout values are set to (3.05s connect, 10s read); adjust if the auth service has known higher latency.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*