### PR TITLE
Add timeout to requests call to prevent DoS (CWE-770)

### DIFF
--- a/application/common/auth.py
+++ b/application/common/auth.py
@@ -21,7 +21,7 @@ def fetch_credentials(username: str, authpoint: str, headers=None) -> dict:
     cust_headers = {}
     if headers:
         cust_headers["Authorization"] = headers
-    response = requests.get(url, headers=cust_headers)
+    response = requests.get(url, headers=cust_headers, timeout=float(getenv("AUTH_HTTP_TIMEOUT", "5")))
     if response.ok:
         data = {}
         if response.status_code != 204:


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Add timeout to auth service requests.get call in `application/common/auth.py` (Line: 24)

**Risk:** Outbound HTTP calls made via `requests.get()` without a timeout can hang indefinitely, consuming worker threads/sockets and enabling a denial-of-service via resource exhaustion (CWE-770).

**Fix:** Added an explicit `timeout` to the `requests.get()` call in `fetch_credentials`, configurable via `AUTH_HTTP_TIMEOUT` (default 5s) to prevent unbounded hangs.

**Review notes:** If the auth service is slow in some environments, adjust `AUTH_HTTP_TIMEOUT` accordingly.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*