### PR TITLE
Add timeout to requests call to prevent DoS in auth client

### DIFF
--- a/application/common/auth.py
+++ b/application/common/auth.py
@@ -21,7 +21,7 @@ def fetch_credentials(username: str, authpoint: str, headers=None) -> dict:
     cust_headers = {}
     if headers:
         cust_headers["Authorization"] = headers
-    response = requests.get(url, headers=cust_headers)
+    response = requests.get(url, headers=cust_headers, timeout=10)
     if response.ok:
         data = {}
         if response.status_code != 204:


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Add timeout to auth service requests call in `application/common/auth.py` (Line: 24)

**Risk:** Outbound HTTP requests made with `requests.get()` had no timeout, allowing connections to hang indefinitely and exhaust worker threads/sockets, resulting in a DoS condition (CWE-770).

**Fix:** Added an explicit `timeout=10` to the `requests.get()` call used to fetch credentials from the auth service, ensuring connections fail fast instead of hanging forever.

**Review notes:** If the auth service is slow in some environments, adjust the timeout value accordingly.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*