### PR TITLE
Suppress false positive XSS finding in template

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
         {% for product in products %}
             <li>
                 <h3>{{ product.name }}</h3>
-                <img src="{{ url_for('static', filename=product.image) }}" alt="{{ product.name }}" width="150">
+                <img src="{{ url_for('static', filename=product.image) }}" alt="{{ product.name }}" width="150"> <!-- noboost -->
                 <p>{{ product.description }}</p>
                 <p>Price: ${{ '%.2f'|format(product.price) }}</p>
             </li>


### PR DESCRIPTION
## Summary

This PR dismisses 1 false positive identified by BoostSecurity (suppressed via `noboost`).

---

## False Positives

### `index.html` (Line 18) — CWE-79

**Justification:** The flagged template uses Django/Jinja-style `{{ ... }}` output only in normal HTML text/attribute contexts, and there are no `<script>`, `<style>`, `innerHTML`, `document.write`, or backtick/template-literal sinks in `index.html`. The only URL attributes are built with `url_for(...)`, which fixes the route/static endpoint rather than rendering attacker-controlled schemes, and the remaining interpolations are auto-escaped template output.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*