### PR TITLE
Resolve false positive XSS finding in index template

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
         {% for product in products %}
             <li>
                 <h3>{{ product.name }}</h3>
-                <img src="{{ url_for('static', filename=product.image) }}" alt="{{ product.name }}" width="150">
+                <img src="{{ url_for('static', filename=product.image) }}" alt="{{ product.name }}" width="150"> <!-- noboost -->
                 <p>{{ product.description }}</p>
                 <p>Price: ${{ '%.2f'|format(product.price) }}</p>
             </li>


### PR DESCRIPTION
## Summary

This PR dismisses 1 false positive identified by BoostSecurity (suppressed via `noboost`).

---

## False Positives

### `index.html` (Line 18) — CWE-79

**Justification:** The flagged line is an <img src> built with Flask/Jinja2 `url_for('static', filename=product.image)`, not any of the reported XSS sinks such as `innerHTML`, `eval`, `document.write`, template literals, or raw URL interpolation. Jinja2 auto-escapes attribute values, and `url_for('static', ...)` generates an application-rooted static URL rather than allowing attacker-controlled `javascript:` or `data:` protocols.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*