### PR TITLE
Resolve flagged XSS false positive in template

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
         {% for product in products %}
             <li>
                 <h3>{{ product.name }}</h3>
-                <img src="{{ url_for('static', filename=product.image) }}" alt="{{ product.name }}" width="150">
+                <img src="{{ url_for('static', filename=product.image) }}" alt="{{ product.name }}" width="150"> <!-- noboost -->
                 <p>{{ product.description }}</p>
                 <p>Price: ${{ '%.2f'|format(product.price) }}</p>
             </li>


### PR DESCRIPTION
## Summary

This PR dismisses 1 false positive identified by BoostSecurity (suppressed via `noboost`).

---

## False Positives

### `index.html` (Line 18) — CWE-79

**Justification:** The flagged line is a Jinja2 `url_for('static', filename=product.image)` call inside an `<img src>` attribute, not a raw unescaped template interpolation. Jinja2 auto-escapes attribute values and `url_for` constructs an application-relative URL path, so the reported dangerous patterns (`document.write`, `eval`, `innerHTML`, backtick injection, or unescaped attacker-controlled URL attributes such as `javascript:`) are not present here.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*