### PR TITLE
Resolve reported XSS finding in index.html as false positive

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
         {% for product in products %}
             <li>
                 <h3>{{ product.name }}</h3>
-                <img src="{{ url_for('static', filename=product.image) }}" alt="{{ product.name }}" width="150">
+                <img src="{{ url_for('static', filename=product.image) }}" alt="{{ product.name }}" width="150"> <!-- noboost -->
                 <p>{{ product.description }}</p>
                 <p>Price: ${{ '%.2f'|format(product.price) }}</p>
             </li>


### PR DESCRIPTION
## Summary

This PR dismisses 1 false positive identified by BoostSecurity (suppressed via `noboost`).

---

## False Positives

### `index.html` (Line 18) — CWE-79

**Justification:** index.html is a Jinja2 template and the flagged line is a normal Jinja expression used inside an <img src> attribute: `{{ url_for('static', filename=product.image) }}`. Jinja2 auto-escapes HTML attributes and `url_for()` constructs a path under the app’s static route (not a user-supplied full URL), so it cannot produce a `javascript:`/data URI or execute script; there is no use of eval/document.write/innerHTML/template literals in this file.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*