### PR TITLE
Suppress false-positive XSS finding in Jinja2 index template

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
         {% for product in products %}
             <li>
                 <h3>{{ product.name }}</h3>
-                <img src="{{ url_for('static', filename=product.image) }}" alt="{{ product.name }}" width="150">
+                <img src="{{ url_for('static', filename=product.image) }}" alt="{{ product.name }}" width="150"> <!-- noboost -->
                 <p>{{ product.description }}</p>
                 <p>Price: ${{ '%.2f'|format(product.price) }}</p>
             </li>


### PR DESCRIPTION
## Summary

This PR dismisses 1 false positive identified by BoostSecurity (suppressed via `noboost`).

---

## False Positives

### `index.html` (Line 18) — CWE-79

**Justification:** The template is a Jinja2 HTML template that uses auto-escaped `{{ ... }}` for `product.name` and `product.description`; there are no `<script>` or `<style>` blocks, no `document.write/eval`, no `.innerHTML/.outerHTML`, and the `href`/`src` attributes are constructed via Flask/Jinja `url_for(...)` (including `filename=product.image`), which generates same-origin paths and does not allow `javascript:` protocol injection.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*