### PR TITLE
Resolve XSS template finding in index.html (false positive)

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
         {% for product in products %}
             <li>
                 <h3>{{ product.name }}</h3>
-                <img src="{{ url_for('static', filename=product.image) }}" alt="{{ product.name }}" width="150">
+                <img src="{{ url_for('static', filename=product.image) }}" alt="{{ product.name }}" width="150"> <!-- noboost -->
                 <p>{{ product.description }}</p>
                 <p>Price: ${{ '%.2f'|format(product.price) }}</p>
             </li>


### PR DESCRIPTION
## Summary

This PR dismisses 1 false positive identified by BoostSecurity (suppressed via `noboost`).

---

## False Positives

### `index.html` (Line 18) — CWE-79

**Justification:** The flagged line is within a Jinja2 template expression used in an HTML attribute: `{{ url_for('static', filename=product.image) }}`. There are no `<script>` blocks, no `eval()`/`document.write()`, no `.innerHTML`/`.outerHTML` DOM sinks, no backtick template literals, and URL generation uses Flask/Jinja2 `url_for()` which URL-encodes path components; Jinja2 auto-escaping applies to other interpolations, so the specific dangerous patterns described are not present in this file.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*