### PR TITLE
Resolve false positive XSS finding in template

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
         {% for product in products %}
             <li>
                 <h3>{{ product.name }}</h3>
-                <img src="{{ url_for('static', filename=product.image) }}" alt="{{ product.name }}" width="150">
+                <img src="{{ url_for('static', filename=product.image) }}" alt="{{ product.name }}" width="150"> <!-- noboost -->
                 <p>{{ product.description }}</p>
                 <p>Price: ${{ '%.2f'|format(product.price) }}</p>
             </li>


### PR DESCRIPTION
## Summary

This PR dismisses 1 false positive identified by BoostSecurity (suppressed via `noboost`).

---

## False Positives

### `index.html` (Line 18) — CWE-79

**Justification:** The flagged line only uses Jinja2 template interpolation inside an `<img src>` attribute via `url_for('static', filename=product.image)`. There are no `<script>` or `<style>` blocks, no `document.write`/`eval`, no `.innerHTML`/`.outerHTML`, and `url_for` constructs a same-origin static path rather than emitting attacker-controlled `javascript:` or `data:` URLs.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*