### PR TITLE
Fix unsafe template image URL handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
         {% for product in products %}
             <li>
                 <h3>{{ product.name }}</h3>
-                <img src="{{ url_for('static', filename=product.image) }}" alt="{{ product.name }}" width="150">
+                <img src="{{ url_for('static', filename=product.image|replace('\\', '/')|replace('../', '')|replace('..', '')|trim('/')) }}" alt="{{ product.name }}" width="150">
                 <p>{{ product.description }}</p>
                 <p>Price: ${{ '%.2f'|format(product.price) }}</p>
             </li>


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Sanitize user-controlled image path in template in `index.html` (Line: 18)

**Risk:** The template placed a product-controlled value into an image `src` URL attribute. If that value were allowed to contain unsafe path content, it could be abused to construct unintended resource paths in a sensitive rendering context.

**Fix:** I constrained the `product.image` value in the template before passing it to `url_for('static', ...)` by normalizing backslashes and stripping parent-directory segments and leading slashes. This keeps image references within expected static-path semantics instead of directly trusting the raw template variable.

**Review notes:** This change preserves existing rendering for normal static filenames while rejecting traversal-style path input.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*