### PR TITLE
Fix SSRF in auth credential lookup

### DIFF
--- a/application/common/auth.py
+++ b/application/common/auth.py
@@ -1,5 +1,6 @@
 from functools import wraps
 from os import getenv
+from urllib.parse import quote
 from django.http import HttpResponseBadRequest
 
 import jwt
@@ -7,6 +8,7 @@ import requests
 
 __AUTH_SERVICE = getenv("AUTH_SERVICE", "105.112.171.112:7101")
 __TOKEN_TYPE = "Bearer"
+__ALLOWED_AUTHPOINTS = {"jira", "p4", "sso", "plm"}
 
 
 def decode_token(token: str) -> dict:
@@ -17,7 +19,11 @@ def decode_token(token: str) -> dict:
 
 
 def fetch_credentials(username: str, authpoint: str, headers=None) -> dict:
-    url = f"http://{__AUTH_SERVICE}/v1/{authpoint}/get?session_id={username}"
+    if authpoint not in __ALLOWED_AUTHPOINTS:
+        raise ValueError(f"Unsupported auth point: {authpoint}")
+
+    encoded_username = quote(username, safe="")
+    url = f"http://{__AUTH_SERVICE}/v1/{authpoint}/get?session_id={encoded_username}"
     cust_headers = {}
     if headers:
         cust_headers["Authorization"] = headers


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Fix SSRF in auth credential lookup in `application/common/auth.py` (Line: 24)

**Risk:** User-controlled values were interpolated directly into the outbound authentication service URL, allowing crafted `authpoint` or `username` values to alter the request target and potentially trigger SSRF-style requests to unintended endpoints.

**Fix:** Added a strict allowlist for supported `authpoint` values and URL-encoded the `username` before building the request URL, ensuring untrusted input cannot change the destination path or query structure of the `requests.get()` call.

**Review notes:** Invalid auth points now raise `ValueError` instead of being sent to the auth service.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*