### PR TITLE
Fix assert-based security check in database fixture

### DIFF
--- a/application/collector/scripts/atabase.py
+++ b/application/collector/scripts/atabase.py
@@ -28,7 +28,8 @@ class Database(DockerService):
         async with create_engine(self.target.sqlalchemy_url) as engine:
             async with engine.begin() as conn:
                 result = self._drop_db(engine, conn)
-                assert iscoroutine(result)  # noqa: S101 use of assert # Typeguard
+                if not iscoroutine(result):
+                    raise TypeError("Expected _drop_db() to return a coroutine for async connections")
                 await result
 
     def _drop_db(


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Replace assert with explicit runtime check in database fixture in `application/collector/scripts/atabase.py` (Line: 31)

**Risk:** The database fixture relied on a Python `assert` to verify that `_drop_db()` returned a coroutine before awaiting it. In optimized Python runs, that assertion would be stripped, allowing the check to disappear and potentially causing unsafe or undefined async behavior.

**Fix:** Replaced the `assert` with an explicit runtime `TypeError` guard that always executes, even under `-O` or `-OO`, before awaiting the result.

**Review notes:** No functional change is intended beyond preserving the validation in production runtimes.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*