### PR TITLE
Enable Jinja autoescaping in collector renderer

### DIFF
--- a/application/collector/scripts/render.py
+++ b/application/collector/scripts/render.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-from jinja2 import Environment, PackageLoader, StrictUndefined
+from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescape
 
 
 @dataclass
@@ -13,7 +13,7 @@ class Model:
 
 
 JINJA_ENV = Environment(
-    autoescape=False,
+    autoescape=select_autoescape(enabled_extensions=("html", "htm", "xml", "jinja2"), default_for_string=True),
     undefined=StrictUndefined,
     trim_blocks=True,
     lstrip_blocks=True,


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Enable Jinja autoescaping for HTML template rendering in `application/collector/scripts/render.py` (Lines: 15-21)

**Risk:** The Jinja environment explicitly disabled autoescaping, so attacker-controlled values rendered into HTML templates could be emitted as raw markup or script and execute in a user's browser.

**Fix:** Enabled Jinja autoescaping with `select_autoescape(...)` for HTML/XML/Jinja template rendering and string-based templates, while preserving the existing loader and strict undefined behavior.

**Review notes:** Template output that previously relied on raw HTML will now be escaped unless it is explicitly marked safe.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*