### PR TITLE
Enable Jinja autoescaping in collector renderer

### DIFF
--- a/application/collector/scripts/render.py
+++ b/application/collector/scripts/render.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-from jinja2 import Environment, PackageLoader, StrictUndefined
+from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescape
 
 
 @dataclass
@@ -13,7 +13,11 @@ class Model:
 
 
 JINJA_ENV = Environment(
-    autoescape=False,
+    autoescape=select_autoescape(
+        enabled_extensions=("html", "htm", "xml", "jinja2"),
+        default_for_string=True,
+        default=True,
+    ),
     undefined=StrictUndefined,
     trim_blocks=True,
     lstrip_blocks=True,


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Enable Jinja autoescaping for rendered templates in `application/collector/scripts/render.py` (Lines: 15-21)

**Risk:** The Jinja environment explicitly disabled autoescaping, so attacker-controlled template data such as `model.asset_name` could be rendered into HTML-capable output without escaping and trigger XSS in downstream consumers.

**Fix:** Replaced `autoescape=False` with Jinja's `select_autoescape(...)` and enabled escaping by default for template files, including the repository's `.jinja2` templates, so user-supplied values are HTML-escaped during rendering.

**Review notes:** If any template intentionally needs raw HTML output, it must now opt in explicitly with Jinja's safe mechanisms.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*