### PR TITLE
Enable Jinja autoescaping in ticket renderer

### DIFF
--- a/application/collector/scripts/render.py
+++ b/application/collector/scripts/render.py
@@ -13,7 +13,7 @@ class Model:
 
 
 JINJA_ENV = Environment(
-    autoescape=False,
+    autoescape=True,
     undefined=StrictUndefined,
     trim_blocks=True,
     lstrip_blocks=True,


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Enable Jinja autoescaping for rendered templates in `application/collector/scripts/render.py` (Lines: 15-21)

**Risk:** The Jinja environment explicitly disabled autoescaping while rendering templates that interpolate `model.asset_name`. If attacker-controlled asset names contain HTML or JavaScript, they could be rendered into HTML-capable consumers and execute as XSS.

**Fix:** Enabled Jinja autoescaping in `application/collector/scripts/render.py` so template variables are escaped by default when rendering the issue templates. This preserves existing template usage while preventing injected markup from being emitted as executable content.

**Review notes:** If any template intentionally needs raw HTML in the future, it must opt in explicitly with Jinja's safe-marking features.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*