### PR TITLE
Enable Jinja autoescaping for rendered templates

### DIFF
--- a/application/collector/scripts/render.py
+++ b/application/collector/scripts/render.py
@@ -13,7 +13,7 @@ class Model:
 
 
 JINJA_ENV = Environment(
-    autoescape=False,
+    autoescape=True,
     undefined=StrictUndefined,
     trim_blocks=True,
     lstrip_blocks=True,


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Enable Jinja autoescaping in render templates in `application/collector/scripts/render.py` (Lines: 15-21)

**Risk:** The Jinja environment explicitly disabled autoescaping, so attacker-controlled values such as `model.asset_name` would be inserted into rendered templates without HTML escaping. If these rendered templates are viewed in an HTML-capable context, malicious markup could execute as script and lead to XSS.

**Fix:** Enabled Jinja autoescaping for the shared template environment so user-supplied fields are escaped during template rendering by default. This preserves the existing template flow while preventing untrusted values from being emitted as raw HTML.

**Review notes:** Rendered output will now contain escaped entities for any HTML-special characters in template data.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*