### PR TITLE
Enable Jinja autoescaping in collector renderer

### DIFF
--- a/application/collector/scripts/render.py
+++ b/application/collector/scripts/render.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-from jinja2 import Environment, PackageLoader, StrictUndefined
+from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescape
 
 
 @dataclass
@@ -13,7 +13,10 @@ class Model:
 
 
 JINJA_ENV = Environment(
-    autoescape=False,
+    autoescape=select_autoescape(
+        enabled_extensions=("html", "htm", "xml", "jinja2"),
+        default_for_string=True,
+    ),
     undefined=StrictUndefined,
     trim_blocks=True,
     lstrip_blocks=True,


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Enable Jinja autoescaping for rendered templates in `application/collector/scripts/render.py` (Lines: 15-21)

**Risk:** The Jinja environment explicitly disabled autoescaping, so attacker-controlled values such as `model.asset_name` could be rendered into templates as raw HTML or JavaScript. If those rendered strings are displayed in an HTML-capable client, this can lead to XSS.

**Fix:** Replaced `autoescape=False` with Jinja's `select_autoescape(...)` and enabled escaping for HTML/XML-style templates, including the repository's `.jinja2` templates, while preserving the existing loader and strict undefined behavior.

**Review notes:** Escaped output may render HTML-like input literally instead of interpreting it as markup.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*