### PR TITLE
Suppress non-exploitable Jinja autoescape finding

### DIFF
--- a/application/collector/scripts/render.py
+++ b/application/collector/scripts/render.py
@@ -12,8 +12,8 @@ class Model:
     asset_name: str
 
 
-JINJA_ENV = Environment(
-    autoescape=False,
+JINJA_ENV = Environment(  # noboost
+    autoescape=False,  # noboost
     undefined=StrictUndefined,
     trim_blocks=True,
     lstrip_blocks=True,


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Suppressed false positive: no browser consumer for Jinja output in `application/collector/scripts/render.py` (Lines: 15-21)

The flagged `jinja2.Environment` in `application/collector/scripts/render.py:15` is not exploitable for XSS because the rendered output has no browser/HTML consumer in this repository. A repo-wide search shows `render_issue_summary()` and `render_issue_description()` are only defined in `application/collector/scripts/render.py` and never called elsewhere, and the templates themselves produce Jira summary/description text in `application/collector/scripts/templates/issue-summary.jinja2` and `application/collector/scripts/templates/issue-description.jinja2`, not an HTTP HTML response.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*