### PR TITLE
Fix SSRF via auth service authpoint allowlist

### DIFF
--- a/application/common/auth.py
+++ b/application/common/auth.py
@@ -17,6 +17,10 @@ def decode_token(token: str) -> dict:
 
 
 def fetch_credentials(username: str, authpoint: str, headers=None) -> dict:
+    allowed_authpoints = {"jira", "p4", "sso", "plm"}
+    if authpoint not in allowed_authpoints:
+        raise ValueError(f"Unsupported authpoint: {authpoint}")
+
     url = f"http://{__AUTH_SERVICE}/v1/{authpoint}/get?session_id={username}"
     cust_headers = {}
     if headers:


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Restrict auth service request paths to known authpoints in `application/common/auth.py` (Line: 24)

**Risk:** `application/common/auth.py:24` interpolated the `authpoint` argument into the path sent to `requests.get()`, and `application/collector/handlers/handler.py:27` passed that value from `Handler.get_handler()` into `get_credentials()`. That let any caller that supplied an unexpected auth point steer this server-side request to alternate endpoints on the configured auth service.

**Fix:** Added an allowlist in `fetch_credentials()` so only the supported auth endpoints (`jira`, `p4`, `sso`, `plm`) can be used to build the outbound URL; unsupported values now fail before the HTTP request is made. No dependencies were added.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*