### PR TITLE
Fix SSRF-prone auth service URL construction

### DIFF
--- a/application/common/auth.py
+++ b/application/common/auth.py
@@ -17,11 +17,11 @@ def decode_token(token: str) -> dict:
 
 
 def fetch_credentials(username: str, authpoint: str, headers=None) -> dict:
-    url = f"http://{__AUTH_SERVICE}/v1/{authpoint}/get?session_id={username}"
+    url = f"http://{__AUTH_SERVICE}/v1/{authpoint}/get"
     cust_headers = {}
     if headers:
         cust_headers["Authorization"] = headers
-    response = requests.get(url, headers=cust_headers)
+    response = requests.get(url, headers=cust_headers, params={"session_id": username})
     if response.ok:
         data = {}
         if response.status_code != 204:


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Fix SSRF-prone URL construction in auth client in `application/common/auth.py` (Line: 24)

**Risk:** `get_credentials()` in `application/common/auth.py:40` is called from `Handler.get_handler()` in `application/collector/handlers/handler.py:25`, and attacker-controlled authorization data flows into `fetch_credentials()` where line 24 built the outbound request URL with an f-string and sent it to `requests.get()`. That let untrusted token-derived `username` data alter the requested URL/query string for the internal auth service request.

**Fix:** Changed `fetch_credentials()` to keep the destination URL fixed and pass `session_id` through `requests` query parameter handling instead of concatenating it into the URL string. This prevents untrusted username data from controlling the constructed request URL while preserving the same auth-service call.

**Review notes:** Error reporting still includes the same request path and session identifier text for failed lookups.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*