### PR TITLE
Suppress false positive Jinja autoescape finding

### DIFF
--- a/application/collector/scripts/render.py
+++ b/application/collector/scripts/render.py
@@ -12,8 +12,8 @@ class Model:
     asset_name: str
 
 
-JINJA_ENV = Environment(
-    autoescape=False,
+JINJA_ENV = Environment(  # noboost
+    autoescape=False,  # noboost
     undefined=StrictUndefined,
     trim_blocks=True,
     lstrip_blocks=True,


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Suppressed false positive: uncalled Jinja rendering helpers in `application/collector/scripts/render.py` (Lines: 15-21)

`render_issue_summary` and `render_issue_description` are dead code in this repository: a repo-wide search for `render_issue_summary\(` and `render_issue_description\(` finds only their definitions in `application/collector/scripts/render.py:27` and `application/collector/scripts/render.py:32`, with no external callers. With no caller, there is no verified attacker-controlled source and no consumer that serves rendered output into an HTML browser context, so the XSS chain is incomplete.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*