### PR TITLE
Suppress false positive SSRF in auth request

### DIFF
--- a/application/common/auth.py
+++ b/application/common/auth.py
@@ -17,11 +17,11 @@ def decode_token(token: str) -> dict:
 
 
 def fetch_credentials(username: str, authpoint: str, headers=None) -> dict:
-    url = f"http://{__AUTH_SERVICE}/v1/{authpoint}/get?session_id={username}"
+    url = f"http://{__AUTH_SERVICE}/v1/{authpoint}/get?session_id={username}"  # noboost
     cust_headers = {}
     if headers:
         cust_headers["Authorization"] = headers
-    response = requests.get(url, headers=cust_headers)
+    response = requests.get(url, headers=cust_headers)  # noboost
     if response.ok:
         data = {}
         if response.status_code != 204:


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Suppressed false positive: no untrusted input reaches auth request in `application/common/auth.py` (Line: 24)

The flagged `requests.get()` sink in `application/common/auth.py:24` is only called with trusted URL components. `fetch_credentials()` receives `authpoint`, but its only in-repo path is `get_credentials()` in `application/common/auth.py:40` from `Handler.get_handler()` in `application/collector/handlers/handler.py:25`, and every external caller passes a fixed module constant: `CONTROLLER_API = "jira"` in `application/collector/controllers/controller_jira.py:7`, `"p4"` in `application/collector/controllers/controller_p4.py:7`, `"plm"` in `application/collector/controllers/controller_plm.py:10`, and `"sso"` in `application/collector/controllers/controller_retriever.py:7`. The request host also comes from the internal `AUTH_SERVICE` environment/config value, so no HTTP parameter, CLI arg, stdin, or other untrusted source controls the outbound URL; the SSRF source link is missing.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*