### PR TITLE
Fix assert-based security check in database script

### DIFF
--- a/application/collector/scripts/atabase.py
+++ b/application/collector/scripts/atabase.py
@@ -28,7 +28,9 @@ class Database(DockerService):
         async with create_engine(self.target.sqlalchemy_url) as engine:
             async with engine.begin() as conn:
                 result = self._drop_db(engine, conn)
-                assert iscoroutine(result)  # noqa: S101 use of assert # Typeguard
+                if not iscoroutine(result):
+                    msg = "Expected asynchronous database drop operation"
+                    raise TypeError(msg)
                 await result
 
     def _drop_db(


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Replace optimized-away assert with explicit runtime check in `application/collector/scripts/atabase.py` (Line: 31)

**Risk:** `Database.drop_database()` in `application/collector/scripts/atabase.py:26` invoked `_drop_db()` and relied on `assert` at `application/collector/scripts/atabase.py:31` to enforce that the returned value was awaitable before awaiting it. Python removes `assert` under optimization, so this runtime type/behavior check disappeared in production and let unexpected non-coroutine results reach the await path unchecked.

**Fix:** Replaced the `assert` with an explicit `if not iscoroutine(result): raise TypeError(...)` guard in `application/collector/scripts/atabase.py`, preserving the validation regardless of optimization flags and keeping the asynchronous contract enforced.

**Review notes:** No caller changes were needed because the method signature and normal successful behavior are unchanged.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*