### PR TITLE
Fix CWE-770 by setting timeout on requests.get in auth

### DIFF
--- a/application/common/auth.py
+++ b/application/common/auth.py
@@ -21,7 +21,8 @@ def fetch_credentials(username: str, authpoint: str, headers=None) -> dict:
     cust_headers = {}
     if headers:
         cust_headers["Authorization"] = headers
-    response = requests.get(url, headers=cust_headers)
+    # Always set a timeout to prevent connections from hanging indefinitely (CWE-770)
+    response = requests.get(url, headers=cust_headers, timeout=(3.05, 10))
     if response.ok:
         data = {}
         if response.status_code != 204:


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Add request timeout to auth service call in `application/common/auth.py` (Line: 24)

**Risk:** An attacker can trigger server-side code paths that call `fetch_credentials()` (application/common/auth.py:18), which issues a `requests.get()` without a timeout (application/common/auth.py:25). This allows the connection to hang indefinitely and tie up worker threads/sockets, leading to resource exhaustion (DoS).

**Fix:** Added an explicit `timeout=(3.05, 10)` to the `requests.get()` call in `fetch_credentials()` so connect/read operations cannot block forever.

**Review notes:** Timeout values may need tuning to match auth-service latency/SLOs.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*